### PR TITLE
Refactored to IAsyncObservable

### DIFF
--- a/Sources/Aggregate.fs
+++ b/Sources/Aggregate.fs
@@ -1,12 +1,15 @@
 namespace Reaction
 
 open System.Threading
-open Types
-open Core
 
-module Aggregate =
-    let scanAsync (initial: 's) (accumulator: 's -> 'a -> Async<'s>) (source: AsyncObservable<'a>) : AsyncObservable<'s> =
-        let subscribe (aobv : AsyncObserver<'s>) =
+[<RequireQualifiedAccess>]
+module Aggregatation =
+    /// Applies an async accumulator function over an observable
+    /// sequence and returns each intermediate result. The seed value is
+    /// used as the initial accumulator value. Returns an observable
+    /// sequence containing the accumulated values.
+    let scanAsync (initial: 's) (accumulator: 's -> 'a -> Async<'s>) (source: IAsyncObservable<'a>) : IAsyncObservable<'s> =
+        let subscribeAsync (aobv : IAsyncObserver<'s>) =
             let mutable state = initial
 
             async {
@@ -16,19 +19,30 @@ module Aggregate =
                         | OnNext x ->
                             let! state' =  accumulator state x
                             state <- state'
-                            do! OnNext state |> aobv
-                        | OnError e -> do! OnError e |> aobv
-                        | OnCompleted -> do! aobv OnCompleted
+                            do! aobv.OnNextAsync state
+                        | OnError e -> do! aobv.OnErrorAsync e
+                        | OnCompleted -> do! aobv.OnCompletedAsync ()
                     }
-                return! source obv
+                return! AsyncObserver obv |> source.SubscribeAsync
             }
-        subscribe
+        { new IAsyncObservable<'s> with member __.SubscribeAsync o = subscribeAsync o }
 
-    let groupBy (keyMapper: 'a -> 'g) (source: AsyncObservable<'a>) : AsyncObservable<AsyncObservable<'a>> =
-        let subscribe (aobv: AsyncObserver<AsyncObservable<'a>>) =
+
+    /// Applies an accumulator function over an observable sequence and
+    /// returns each intermediate result. The seed value is used as the
+    /// initial accumulator value. Returns an observable sequence
+    /// containing the accumulated values.
+    let scan (initial : 's) (scanner:'s -> 'a -> 's) (source: IAsyncObservable<'a>) : IAsyncObservable<'s> =
+        scanAsync initial (fun s x -> async { return scanner s x } ) source
+
+    /// Groups the elements of an observable sequence according to a
+    /// specified key mapper function. Returns a sequence of observable
+    /// groups, each of which corresponds to a given key.
+    let groupBy (keyMapper: 'a -> 'g) (source: IAsyncObservable<'a>) : IAsyncObservable<IAsyncObservable<'a>> =
+        let subscribeAsync (aobv: IAsyncObserver<IAsyncObservable<'a>>) =
             let cancellationSource = new CancellationTokenSource()
             let agent = MailboxProcessor.Start((fun inbox ->
-                let rec messageLoop ((groups, disposed) : Map<'g, AsyncObserver<'a>>*bool) = async {
+                let rec messageLoop ((groups, disposed) : Map<'g, IAsyncObserver<'a>>*bool) = async {
                     let! n = inbox.Receive ()
 
                     if disposed then
@@ -43,13 +57,13 @@ module Aggregate =
                                     match groups.TryFind groupKey with
                                     | Some group ->
                                         //printfn "Found group: %A" groupKey
-                                        do! group n
+                                        do! group.OnNextAsync x
                                         return groups, false
                                     | None ->
                                         //printfn "New group: %A" groupKey
                                         let obv, obs = Streams.singleStream ()
-                                        do! OnNext obs |> aobv
-                                        do! obv n
+                                        do! aobv.OnNextAsync obs
+                                        do! obv.OnNextAsync x
                                         return groups.Add (groupKey, obv), false
                                 }
                                 return newGroups
@@ -57,15 +71,15 @@ module Aggregate =
                                 //printfn "%A" n
 
                                 for entry in groups do
-                                    do! OnError ex |> entry.Value
-                                do! OnError ex |> aobv
+                                    do! entry.Value.OnErrorAsync ex
+                                do! aobv.OnErrorAsync ex
                                 return Map.empty, true
                             | OnCompleted ->
                                 //printfn "%A" n
 
                                 for entry in groups do
-                                    do! OnCompleted |> entry.Value
-                                do! aobv OnCompleted
+                                    do! entry.Value.OnCompletedAsync ()
+                                do! aobv.OnCompletedAsync ()
                                 return Map.empty, true
                         }
 
@@ -79,11 +93,11 @@ module Aggregate =
                     async {
                         agent.Post n
                     }
-                let! subscription = source obv
+                let! subscription = AsyncObserver obv |> source.SubscribeAsync
                 let cancel () = async {
-                    do! subscription ()
+                    do! subscription.DisposeAsync ()
                     cancellationSource.Cancel()
                 }
-                return cancel
+                return AsyncDisposable.Create cancel
             }
-        subscribe
+        { new IAsyncObservable<IAsyncObservable<'a>> with member __.SubscribeAsync o = subscribeAsync o }

--- a/Sources/AsyncObservable.fs
+++ b/Sources/AsyncObservable.fs
@@ -4,361 +4,213 @@ namespace Reaction
 open FSharp.Control
 #endif
 
-[<AutoOpen>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module AsyncObservable =
-    /// AsyncObservable as a single case union type to attach methods such as SubscribeAsync.
-    type AsyncObservable<'a> = AsyncObservable of Types.AsyncObservable<'a> with
-
-        /// Returns the wrapped subscribe function (`AsyncObserver{'a} -> Async{AsyncDisposable}`)
-        static member Unwrap (AsyncObservable obs) : Types.AsyncObservable<'a> = obs
-
-        /// Subscribes the async observer to the async observable
-        member this.SubscribeAsync obv = async {
-            let! disposable = AsyncObserver.Unwrap obv |> AsyncObservable.Unwrap this
-            return AsyncDisposable disposable
-        }
-
-        /// Subscribes the async observer function (`Notification{'a} -> Async{unit}`)
-        /// to the AsyncObservable
-        member this.SubscribeAsync<'a> (obv: Notification<'a> -> Async<unit>) = async{
-            let! disposable = obv |> AsyncObservable.Unwrap this
-            return AsyncDisposable disposable
-        }
-
+    type IAsyncObservable<'a> with
+        /// Repeat each element of the sequence n times
         /// Subscribes the async observer to the async observable,
         /// ignores the disposable
-        member this.RunAsync obv = async {
-            let! _ = AsyncObserver.Unwrap obv |> AsyncObservable.Unwrap this
+        member this.RunAsync (obv: IAsyncObserver<'a>) = async {
+            let! _ = this.SubscribeAsync obv
             return ()
         }
 
         /// Subscribes the observer function (`Notification{'a} -> Async{unit}`)
         /// to the AsyncObservable, ignores the disposable.
         member this.RunAsync<'a> (obv: Notification<'a> -> Async<unit>) = async {
-            do! obv |> AsyncObservable.Unwrap this |> Async.Ignore
+            do! this.SubscribeAsync (AsyncObserver obv) |> Async.Ignore
         }
 
-        /// Returns an observable sequence that contains the elements of
-        /// the two steams, in sequential order.
-        static member (+) (x: AsyncObservable<'a>, y: AsyncObservable<'a>) =
-            Combine.concat [ AsyncObservable.Unwrap x; AsyncObservable.Unwrap y]
-            |> AsyncObservable
+        /// Subscribes the async observer function (`Notification{'a} -> Async{unit}`)
+        /// to the AsyncObservable
+        member this.SubscribeAsync<'a> (obv: Notification<'a> -> Async<unit>) = async {
+            let! disposable = this.SubscribeAsync (AsyncObserver obv)
+            return disposable
+        }
 
-        /// Projects each element of an observable sequence into an
-        /// observable sequence and merges the resulting observable
-        /// sequences back into one observable sequence.
-        static member (>>=) (source:AsyncObservable<'a>, mapper:'a -> Async<AsyncObservable<'b>>) : AsyncObservable<'b> =
-            let mapperUnwrapped p : Async<Types.AsyncObservable<'b>> = async {
-                let! result = mapper p
-                return AsyncObservable.Unwrap result
-            }
-            AsyncObservable.Unwrap source
-            |> Transform.mapAsync mapperUnwrapped
-            |> Combine.mergeInner
-            |> AsyncObservable
-
-    let private mapperUnwrapped (mapper: 'a -> AsyncObservable<'b>) a : Types.AsyncObservable<'b> =
-        let result = mapper a
-        AsyncObservable.Unwrap result
-
-    let private mapperUnwrappedAsync mapper a : Async<Types.AsyncObservable<'b>> = async {
-        let! result = mapper a
-        return AsyncObservable.Unwrap result
-    }
-
-    /// Returns the async observable sequence whose single element is
-    /// the result of the given async workflow.
-    let ofAsync (xs: Async<'a>) : AsyncObservable<'a> =
-        AsyncObservable <| Creation.ofAsync xs
-
-    /// Returns the async observable sequence whose elements are pulled from
-    /// the given enumerable sequence.
-    let ofSeq (xs: seq<'a>) : AsyncObservable<'a> =
-        AsyncObservable <| Creation.ofSeq xs
-
-    /// Returns an observable sequence with no elements.
-    let empty<'a> () : AsyncObservable<'a> =
-        AsyncObservable <| Creation.empty ()
-
-    /// Creates an async observable (`AsyncObservable{'a}`) from the
-    /// given subscribe function.
-    let create (subscribe : AsyncObserver<'a> -> Async<AsyncDisposable>) : AsyncObservable<'a> =
-        let subscribe' (aobv : Types.AsyncObserver<'a>) : Async<Types.AsyncDisposable> =
-            async {
-                let aobv' = AsyncObserver aobv
-                let! subscription = subscribe aobv'
-                return AsyncDisposable.Unwrap subscription
-            }
-
-        AsyncObservable subscribe'
-
-    /// Returns the observable sequence that terminates exceptionally
-    /// with the specified exception.
-    let fail<'a> ex : AsyncObservable<'a> =
-        Creation.fail ex
-        |> AsyncObservable
-
-    /// Returns an observable sequence containing the single specified
-    /// element.
-    let single (x: 'a) : AsyncObservable<'a> =
-        Creation.single x
-        |> AsyncObservable
-
-    /// Returns an observable sequence that triggers the increasing
-    /// sequence starting with 0 after the given period.
-    let interval periodInMilliseconds : AsyncObservable<int> =
-        Creation.timer periodInMilliseconds periodInMilliseconds |> AsyncObservable
-
-    /// Returns an observable sequence that triggers the value 0
-    /// after the given duetime.
-    let timer dueTime : AsyncObservable<int> =
-        Creation.timer dueTime 0 |> AsyncObservable
-
-    /// Time shifts the observable sequence by the given timeout. The
-    /// relative time intervals between the values are preserved.
-    let delay msecs (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Timeshift.delay msecs
-        |> AsyncObservable
-
-    /// Ignores values from an observable sequence which are followed by
-    /// another value before the given timeout.
-    let debounce msecs (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Timeshift.debounce msecs
-        |> AsyncObservable
-
-    let zipSeq (sequence: seq<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'a*'b> =
-        source
-        |> AsyncObservable.Unwrap
-        |> Combine.zipSeq sequence
-        |> AsyncObservable
-
-    /// Returns an observable sequence whose elements are the result of
-    /// invoking the async mapper function on each element of the source.
-    let mapAsync (mapper:'a -> Async<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        AsyncObservable.Unwrap source
-        |> Transform.mapAsync mapper
-        |> AsyncObservable
-
-    /// Returns an observable sequence whose elements are the result of
-    /// invoking the mapper function on each element of the source.
-    let map (mapper:'a -> 'b) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        mapAsync (fun x -> async { return mapper x }) source
-
-    /// Returns an observable sequence whose elements are the result of
-    /// invoking the async mapper function by incorporating the element's
-    /// index on each element of the source.
-    let mapiAsync (mapper:'a*int -> Async<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> zipSeq Core.infinite
-        |> mapAsync mapper
-
-    /// Returns an observable sequence whose elements are the result of
-    /// invoking the mapper function and incorporating the element's
-    /// index on each element of the source.
-    let mapi (mapper:'a*int -> 'b) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        mapiAsync (fun (x, i) -> async { return mapper (x, i) }) source
-
-    // Applies the given async function to each element of the stream and
-    /// returns the stream comprised of the results for each element
-    /// where the function returns Some with some value.
-    let chooseAsync (chooser: 'a -> Async<'b option>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        AsyncObservable.Unwrap source
-        |> Filter.chooseAsync chooser
-        |> AsyncObservable
-
-    /// Applies the given function to each element of the stream and
-    /// returns the stream comprised of the results for each element
-    /// where the function returns Some with some value.
-    let choose (chooser: 'a -> 'b option) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        chooseAsync  (fun x -> async { return chooser x }) source
-
-    /// Merges an observable sequence of observable sequences into an
-    /// observable sequence.
-    let inline mergeInner (source: AsyncObservable<AsyncObservable<'a>>) : AsyncObservable<'a> =
-        source
-        |> map AsyncObservable.Unwrap
-        |> AsyncObservable.Unwrap
-        |> Combine.mergeInner
-        |> AsyncObservable
-
-    /// Merges an observable sequence with another observable sequences.
-    let inline merge (other : AsyncObservable<'a>) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        ofSeq [source; other] |> mergeInner
-
-    /// Returns an observable sequence that contains the elements of each given
-    /// sequences, in sequential order.
-    let inline concat (sources : seq<AsyncObservable<'a>>) : AsyncObservable<'a> =
-        Seq.map AsyncObservable.Unwrap sources
-        |> Combine.concat
-        |> AsyncObservable
-
-    /// Projects each element of an observable sequence into an
-    /// observable sequence and merges the resulting observable
-    /// sequences back into one observable sequence.
-    let flatMap (mapper:'a -> AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> map mapper
-        |> mergeInner
-
-    /// Projects each element of an observable sequence into an
-    /// observable sequence by incorporating the element's
-    /// index on each element of the source. Merges the resulting
-    /// observable sequences back into one observable sequence.
-    let flatMapi (mapper:'a*int -> AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> mapi mapper
-        |> mergeInner
-
-    /// Asynchronously projects each element of an observable sequence
-    /// into an observable sequence and merges the resulting observable
-    /// sequences back into one observable sequence.
-    let flatMapAsync (mapper:'a -> Async<AsyncObservable<'b>>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> mapAsync mapper
-        |> mergeInner
-
-    /// Asynchronously projects each element of an observable sequence
-    /// into an observable sequence by incorporating the element's
-    /// index on each element of the source. Merges the resulting
-    /// observable sequences back into one observable sequence.
-    let flatMapiAsync (mapper:'a*int -> Async<AsyncObservable<'b>>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> mapiAsync mapper
-        |> mergeInner
-
-    /// Transforms an observable sequence of observable sequences into
-    /// an observable sequence producing values only from the most
-    /// recent observable sequence.
-    let switchLatest (source: AsyncObservable<AsyncObservable<'a>>) : AsyncObservable<'a> =
-        source
-        |> map AsyncObservable.Unwrap
-        |> AsyncObservable.Unwrap
-        |> Transform.switchLatest
-        |> AsyncObservable
-
-    /// Transforms the items emitted by an source sequence into
-    /// observable streams, and mirror those items emitted by the
-    /// most-recently transformed observable sequence.
-    let flatMapLatest (mapper: 'a -> AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> map mapper
-        |> switchLatest
-
-    /// Asynchronosly transforms the items emitted by an source sequence
-    /// into observable streams, and mirror those items emitted by the
-    /// most-recently transformed observable sequence.
-    let flatMapLatestAsync (mapper: 'a -> Async<AsyncObservable<'b>>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        source
-        |> mapAsync mapper
-        |> switchLatest
-
-    /// Filters the elements of an observable sequence based on an async
-    /// predicate. Returns an observable sequence that contains elements
-    /// from the input sequence that satisfy the condition.
-    let filterAsync (predicate: 'a -> Async<bool>) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Filter.filterAsync predicate
-        |> AsyncObservable
-
-    /// Filters the elements of an observable sequence based on a
-    /// predicate. Returns an observable sequence that contains elements
-    /// from the input sequence that satisfy the condition.
-    let filter (predicate: 'a -> bool) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        filterAsync (fun x -> async { return predicate x }) source
-
-    /// Return an observable sequence only containing the distinct
-    /// contiguous elementsfrom the source sequence.
-    let distinctUntilChanged (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Filter.distinctUntilChanged
-        |> AsyncObservable
+    // Aggregate
+    let groupBy = Aggregatation.groupBy
+    /// Applies an accumulator function over an observable sequence and
+    /// returns each intermediate result. The seed value is used as the
+    /// initial accumulator value. Returns an observable sequence
+    /// containing the accumulated values.
+    let scan = Aggregatation.scan
 
     /// Applies an async accumulator function over an observable
     /// sequence and returns each intermediate result. The seed value is
     /// used as the initial accumulator value. Returns an observable
     /// sequence containing the accumulated values.
-    let scanAsync (initial : 's) (scanner:'s -> 'a -> Async<'s>) (source: AsyncObservable<'a>) : AsyncObservable<'s> =
-        AsyncObservable.Unwrap source
-        |> Aggregate.scanAsync initial scanner
-        |> AsyncObservable
+    let scanAsync = Aggregatation.scanAsync
 
-    /// Applies an accumulator function over an observable sequence and
-    /// returns each intermediate result. The seed value is used as the
-    /// initial accumulator value. Returns an observable sequence
-    /// containing the accumulated values.
-    let scan (initial : 's) (scanner:'s -> 'a -> 's) (source: AsyncObservable<'a>) : AsyncObservable<'s> =
-        scanAsync initial (fun s x -> async { return scanner s x } ) source
-
-    /// A stream is both an observable sequence as well as an observer.
-    /// Each notification is broadcasted to all subscribed observers.
-    let stream<'a> () : AsyncObserver<'a> * AsyncObservable<'a> =
-        let obv, obs = Streams.stream ()
-        AsyncObserver obv, AsyncObservable obs
-
-    /// A mailbox stream is a subscribable mailbox. Each message is
-    /// broadcasted to all subscribed observers.
-    let mbStream<'a> () : MailboxProcessor<'a> * AsyncObservable<'a> =
-        let mb, obs = Streams.mbStream ()
-        mb, AsyncObservable obs
-
-    /// Returns an observable sequence containing the first sequence's
-    /// elements, followed by the elements of the handler sequence in
-    /// case an exception occurred.
-    let catch (handler: exn -> AsyncObservable<'a>) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Transform.catch (mapperUnwrapped handler)
-        |> AsyncObservable
-
-    /// Prepends a sequence of values to an observable sequence.
-    /// Returns the source sequence prepended with the specified values.
-    let inline startWith (items : seq<'a>) (source: AsyncObservable<'a>) =
-        concat [ofSeq items; source]
+    // Combine
 
     /// Merges the specified observable sequences into one observable
     /// sequence by combining elements of the sources into tuples.
     /// Returns an observable sequence containing the combined results.
-    let inline combineLatest (other : AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'a*'b> =
-        AsyncObservable.Unwrap source
-        |> Combine.combineLatest (AsyncObservable.Unwrap other)
-        |> AsyncObservable
+    let combineLatest = Combine.combineLatest
+
+    /// Returns an observable sequence that contains the elements of
+    /// each given sequences, in sequential order.
+    let concat = Combine.concat
+
+    /// Merges an observable sequence with another observable sequences.
+    let merge = Combine.merge
+
+    /// Merges an observable sequence of observable sequences into an
+    /// observable sequence.
+    let mergeInner = Combine.mergeInner
+
+    /// Prepends a sequence of values to an observable sequence.
+    /// Returns the source sequence prepended with the specified values.
+    let startWith = Combine.startWith
 
     /// Merges the specified observable sequences into one observable
     /// sequence by combining the values into tuples only when the first
     /// observable sequence produces an element. Returns the combined
     /// observable sequence.
-    let inline withLatestFrom (other : AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'a*'b> =
-        AsyncObservable.Unwrap source
-        |> Combine.withLatestFrom (AsyncObservable.Unwrap other)
-        |> AsyncObservable
+    let withLatestFrom = Combine.withLatestFrom
+    let zipSeq = Combine.zipSeq
 
-    /// Groups the elements of an observable sequence according to a
-    /// specified key mapper function. Returns a sequence of observable
-    /// groups, each of which corresponds to a given key.
-    let groupBy (keyMapper: 'a -> 'g) (source: AsyncObservable<'a>) : AsyncObservable<AsyncObservable<'a>> =
-        AsyncObservable.Unwrap source
-        |> Aggregate.groupBy keyMapper
-        |> AsyncObservable
-        |> map AsyncObservable
+    // Creation
+
+    /// Creates an async observable (`AsyncObservable{'a}`) from the
+    /// given subscribe function.
+    let create = Create.create
+
+    let defer = Create.defer
+
+    /// Returns an observable sequence with no elements.
+    let empty<'a> = Create.empty<'a>
+
+    /// Returns the observable sequence that terminates exceptionally
+    /// with the specified exception.
+    let fail<'a> = Create.fail<'a>
+
+    /// Returns an observable sequence that triggers the increasing
+    /// sequence starting with 0 after the given period.
+    let interval = Create.interval
+    let ofAsync = Create.ofAsync
+#if !FABLE_COMPILER
+    let ofAsyncSeq = Create.ofAsyncSeq
+#endif
+    /// Returns the async observable sequence whose elements are pulled
+    /// from the given enumerable sequence.
+    let ofSeq = Create.ofSeq
+    /// Returns an observable sequence containing the single specified
+    /// element.
+    let single = Create.single
+
+    /// Returns an observable sequence that triggers the value 0
+    /// after the given duetime.
+    let timer = Create.timer
+
+    // Filter
+
+    /// Applies the given function to each element of the stream and
+    /// returns the stream comprised of the results for each element
+    /// where the function returns Some with some value.
+    let choose = Filter.choose
+
+    /// Applies the given async function to each element of the stream and
+    /// returns the stream comprised of the results for each element
+    /// where the function returns Some with some value.
+    let chooseAsync = Filter.chooseAsync
+
+    /// Return an observable sequence only containing the distinct
+    /// contiguous elementsfrom the source sequence.
+    let distinctUntilChanged =Filter.distinctUntilChanged
+
+    /// Filters the elements of an observable sequence based on a
+    /// predicate. Returns an observable sequence that contains elements
+    /// from the input sequence that satisfy the condition.
+    let filter = Filter.filter
+
+    /// Filters the elements of an observable sequence based on an async
+    /// predicate. Returns an observable sequence that contains elements
+    /// from the input sequence that satisfy the condition.
+    let filterAsync = Filter.filterAsync
 
     /// Returns the values from the source observable sequence until the
     /// other observable sequence produces a value.
-    let takeUntil (other: AsyncObservable<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        AsyncObservable.Unwrap source
-        |> Filter.takeUntil (AsyncObservable.Unwrap other)
-        |> AsyncObservable
+    let takeUntil = Filter.takeUntil
 
+    // Leave
 #if !FABLE_COMPILER
-    /// Convert async sequence into an async observable.
-    let ofAsyncSeq (xs: AsyncSeq<'a>) : AsyncObservable<'a> =
-        Creation.ofAsyncSeq xs
-        |> AsyncObservable
-
     /// Convert async observable to async sequence, non-blocking.
     /// Producer will be awaited until item is consumed by the async
     /// enumerator.
-    let toAsyncSeq (source: AsyncObservable<'a>) : AsyncSeq<'a> =
-        AsyncObservable.Unwrap source
-        |> Leave.toAsyncSeq
+    let toAsyncSeq = Leave.toAsyncSeq
 #endif
+
+    // Timeshift
+
+    /// Ignores values from an observable sequence which are followed by
+    /// another value before the given timeout.
+    let debounce = Timeshift.debounce
+
+    /// Time shifts the observable sequence by the given timeout. The
+    /// relative time intervals between the values are preserved.
+    let delay = Timeshift.delay
+
+    // Transform
+
+    /// Returns an observable sequence containing the first sequence's
+    /// elements, followed by the elements of the handler sequence in
+    /// case an exception occurred.
+    let catch = Transformation.catch
+
+    /// Projects each element of an observable sequence into an
+    /// observable sequence and merges the resulting observable
+    /// sequences back into one observable sequence.
+    let flatMap = Transformation.flatMap
+
+    /// Asynchronously projects each element of an observable sequence
+    /// into an observable sequence and merges the resulting observable
+    /// sequences back into one observable sequence.
+    let flatMapAsync = Transformation.flatMapAsync
+
+    /// Projects each element of an observable sequence into an
+    /// observable sequence by incorporating the element's
+    /// index on each element of the source. Merges the resulting
+    /// observable sequences back into one observable sequence.
+    let flatMapi = Transformation.flatMapi
+
+    /// Asynchronously projects each element of an observable sequence
+    /// into an observable sequence by incorporating the element's
+    /// index on each element of the source. Merges the resulting
+    /// observable sequences back into one observable sequence.
+    let flatMapiAsync = Transformation.flatMapiAsync
+
+    /// Transforms the items emitted by an source sequence into
+    /// observable streams, and mirror those items emitted by the
+    /// most-recently transformed observable sequence.
+    let flatMapLatest = Transformation.flatMapLatest
+
+    /// Asynchronosly transforms the items emitted by an source sequence
+    /// into observable streams, and mirror those items emitted by the
+    /// most-recently transformed observable sequence.
+    let flatMapLatestAsync = Transformation.flatMapLatestAsync
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the mapper function on each element of the source.
+    let map = Transformation.map
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the async mapper function on each element of the source.
+    let mapAsync = Transformation.mapAsync
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the mapper function and incorporating the element's
+    /// index on each element of the source.
+    let mapi = Transformation.mapi
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the async mapper function by incorporating the element's
+    /// index on each element of the source.
+    let mapiAsync = Transformation.mapiAsync
+
+    /// Transforms an observable sequence of observable sequences into
+    /// an observable sequence producing values only from the most
+    /// recent observable sequence.
+    let switchLatest = Transformation.switchLatest
+

--- a/Sources/AsyncObserver.fs
+++ b/Sources/AsyncObserver.fs
@@ -1,13 +1,11 @@
 namespace Reaction
 
-[<AutoOpen>]
-module AsyncObserver =
-    type AsyncObserver<'a> = AsyncObserver of Types.AsyncObserver<'a> with
-        static member Unwrap (AsyncObserver obv) : Types.AsyncObserver<'a> = obv
+type AsyncObserver<'a> (fn: Notification<'a> -> Async<unit>) =
 
-        member this.OnNextAsync (x: 'a) = AsyncObserver.Unwrap this <| OnNext x
-        member this.OnErrorAsync err = AsyncObserver.Unwrap this <| OnError err
-        member this.OnCompletedAsync () = AsyncObserver.Unwrap this <| OnCompleted
+    interface Types.IAsyncObserver<'a> with
+        member this.OnNextAsync (x: 'a) =  OnNext x |> fn
+        member this.OnErrorAsync err = OnError err |> fn
+        member this.OnCompletedAsync () = OnCompleted |> fn
 
-        member this.PostAsync n = AsyncObserver.Unwrap this n
+    member this.PostAsync n = fn n
 

--- a/Sources/Query.fs
+++ b/Sources/Query.fs
@@ -1,20 +1,24 @@
 namespace Reaction
 
 type QueryBuilder() =
-    member this.Zero () : AsyncObservable<_> = empty ()
-    member this.Yield (x: 'a) : AsyncObservable<'a> = single x
-    member this.YieldFrom (xs: AsyncObservable<'a>) : AsyncObservable<'a> = xs
-    member this.Combine (xs: AsyncObservable<'a>, ys: AsyncObservable<'a>) = xs + ys
+    member this.Zero () : IAsyncObservable<_> = Create.empty ()
+    member this.Yield (x: 'a) : IAsyncObservable<'a> = Create.single x
+    member this.YieldFrom (xs: IAsyncObservable<'a>) : IAsyncObservable<'a> = xs
+    member this.Combine (xs: IAsyncObservable<'a>, ys: IAsyncObservable<'a>) = Combine.concat [xs; ys]
     member this.Delay (fn) = fn ()
-    member this.Bind(source: AsyncObservable<'a>, fn: 'a -> AsyncObservable<'b>) : AsyncObservable<'b> = flatMap fn source
-    member x.For(source: AsyncObservable<_>, func) : AsyncObservable<'b> = flatMap func source
+    member this.Bind(source: IAsyncObservable<'a>, fn: 'a -> IAsyncObservable<'b>) : IAsyncObservable<'b> = Transformation.flatMap fn source
+    member x.For(source: IAsyncObservable<_>, func) : IAsyncObservable<'b> = Transformation.flatMap func source
 
     // Async to AsyncObservable conversion
-    member this.Bind (source: Async<'a>, fn: 'a -> AsyncObservable<'b>) = ofAsync source |> flatMap fn
-    member this.YieldFrom (xs: Async<'x>) = ofAsync xs
+    member this.Bind (source: Async<'a>, fn: 'a -> IAsyncObservable<'b>) =
+        Create.ofAsync source
+        |> Transformation.flatMap fn
+    member this.YieldFrom (xs: Async<'x>) = Create.ofAsync xs
 
     // Sequence to AsyncObservable conversion
-    member x.For(source: seq<_>, func) : AsyncObservable<'b> = ofSeq source |> flatMap func
+    member x.For(source: seq<_>, func) : IAsyncObservable<'b> =
+        Create.ofSeq source
+        |> Transformation.flatMap func
 
 [<AutoOpen>]
 module Query =

--- a/Sources/Reaction.fsproj
+++ b/Sources/Reaction.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Reaction</PackageId>
-    <Version>0.11.0</Version>
+    <Version>0.12.3</Version>
     <Authors>Dag Brattli</Authors>
     <Company>Brattli Labs</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <Compile Include="Types.fs" />
+    <Compile Include="AsyncDisposable.fs" />
+    <Compile Include="AsyncObserver.fs" />
     <Compile Include="Core.fs" />
     <Compile Include="Stream.fs" />
     <Compile Include="Create.fs" />
@@ -20,8 +22,6 @@
     <Compile Include="Combine.fs" />
     <Compile Include="Transform.fs" />
     <Compile Include="Timeshift.fs" />
-    <Compile Include="AsyncDisposable.fs" />
-    <Compile Include="AsyncObserver.fs" />
     <Compile Include="AsyncObservable.fs" />
     <Compile Include="Query.fs" />
   </ItemGroup>

--- a/Sources/Transform.fs
+++ b/Sources/Transform.fs
@@ -3,106 +3,197 @@ namespace Reaction
 open Types
 open Core
 
-module Transform =
-    // The classic map (select) operator with async mapper
-    let mapAsync (mapper: 'a -> Async<'b>) (source: AsyncObservable<'a>) : AsyncObservable<'b> =
-        let subscribe (aobv : AsyncObserver<'b>) =
+module Transformation =
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the async mapper function on each element of the source.
+    let mapAsync (mapper: 'a -> Async<'b>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        let subscribeAsync (aobv : IAsyncObserver<'b>) : Async<IAsyncDisposable> =
             async {
-                let _obv n =
-                    async {
-                        match n with
-                        | OnNext x ->
+                let _obv =
+                    { new IAsyncObserver<'a> with
+                        member this.OnNextAsync x = async {
                             let! b =  mapper x
-                            do! b |> OnNext |> aobv  // Let exceptions bubble to the top
-                        | OnError ex -> do! OnError ex |> aobv
-                        | OnCompleted -> do! aobv OnCompleted
-
+                            do! aobv.OnNextAsync b
+                        }
+                        member this.OnErrorAsync err = async {
+                            do! aobv.OnErrorAsync err
+                        }
+                        member this.OnCompletedAsync () = async {
+                            do! aobv.OnCompletedAsync ()
+                        }
                     }
-                return! source _obv
+                return! source.SubscribeAsync _obv
             }
-        subscribe
+        { new IAsyncObservable<'b> with member __.SubscribeAsync o = subscribeAsync o }
 
-    let switchLatest (source: AsyncObservable<AsyncObservable<'a>>) : AsyncObservable<'a> =
-        let subscribe (aobv : AsyncObserver<'a>) =
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the mapper function on each element of the source.
+    let map (mapper:'a -> 'b) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        mapAsync (fun x -> async { return mapper x }) source
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the async mapper function by incorporating the element's
+    /// index on each element of the source.
+    let mapiAsync (mapper:'a*int -> Async<'b>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> Combine.zipSeq Core.infinite
+        |> mapAsync mapper
+
+    /// Returns an observable sequence whose elements are the result of
+    /// invoking the mapper function and incorporating the element's
+    /// index on each element of the source.
+    let mapi (mapper:'a*int -> 'b) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        mapiAsync (fun (x, i) -> async { return mapper (x, i) }) source
+
+    /// Projects each element of an observable sequence into an
+    /// observable sequence and merges the resulting observable
+    /// sequences back into one observable sequence.
+    let flatMap (mapper:'a -> IAsyncObservable<'b>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> map mapper
+        |> Combine.mergeInner
+
+    /// Projects each element of an observable sequence into an
+    /// observable sequence by incorporating the element's
+    /// index on each element of the source. Merges the resulting
+    /// observable sequences back into one observable sequence.
+    let flatMapi (mapper:'a*int -> IAsyncObservable<'b>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> mapi mapper
+        |> Combine.mergeInner
+
+    /// Asynchronously projects each element of an observable sequence
+    /// into an observable sequence and merges the resulting observable
+    /// sequences back into one observable sequence.
+    let flatMapAsync (mapper:'a -> Async<IAsyncObservable<'b>>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> mapAsync mapper
+        |> Combine.mergeInner
+
+    /// Asynchronously projects each element of an observable sequence
+    /// into an observable sequence by incorporating the element's
+    /// index on each element of the source. Merges the resulting
+    /// observable sequences back into one observable sequence.
+    let flatMapiAsync (mapper:'a*int -> Async<IAsyncObservable<'b>>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> mapiAsync mapper
+        |> Combine.mergeInner
+
+    /// Transforms an observable sequence of observable sequences into
+    /// an observable sequence producing values only from the most
+    /// recent observable sequence.
+    let switchLatest (source: IAsyncObservable<IAsyncObservable<'a>>) : IAsyncObservable<'a> =
+        let subscribeAsync (aobv : IAsyncObserver<'a>) =
             let safeObserver = safeObserver aobv
             let refCount = refCountAgent 2 (async { // 2 = Main observable + dispsableEmpty.
-                do! safeObserver OnCompleted
+                do! safeObserver.OnCompletedAsync ()
             })
 
             let innerAgent =
-                let obv n =
-                    async {
-                        match n with
-                        | OnCompleted -> refCount.Post Decrease
-                        | _ -> do! safeObserver n
+                let obv = {
+                    new IAsyncObserver<'a> with
+                        member this.OnNextAsync x = async {
+                            do! safeObserver.OnNextAsync x
+                        }
+                        member this.OnErrorAsync err = async {
+                            do! safeObserver.OnErrorAsync err
+                        }
+                        member this.OnCompletedAsync () = async {
+                            refCount.Post Decrease
+                        }
                     }
 
                 MailboxProcessor.Start(fun inbox ->
-                    let rec messageLoop (current: AsyncDisposable) = async {
+                    let rec messageLoop (current: IAsyncDisposable) = async {
                         let! cmd = inbox.Receive()
                         let getCurrent = async {
                             match cmd with
                             | InnerObservable xs ->
-                                do! current ()
+                                do! current.DisposeAsync ()
                                 refCount.Post Decrease
-                                let! inner = xs obv
+                                let! inner = xs.SubscribeAsync obv
                                 return inner
                             | Dispose ->
-                                do! current ()
-                                return disposableEmpty
+                                do! current.DisposeAsync ()
+                                return AsyncDisposable.Empty
                         }
                         let! current' = getCurrent
                         return! messageLoop current'
                     }
 
-                    messageLoop disposableEmpty
+                    messageLoop AsyncDisposable.Empty
                 )
 
             async {
-                let obv (ns: Notification<AsyncObservable<'a>>) =
+                let obv (ns: Notification<IAsyncObservable<'a>>) =
                     async {
                         match ns with
                         | OnNext xs ->
                             refCount.Post Increase
                             InnerObservable xs |> innerAgent.Post
-                        | OnError e -> do! OnError e |> safeObserver
+                        | OnError e -> do! safeObserver.OnErrorAsync e
                         | OnCompleted -> refCount.Post Decrease
                     }
 
-                let! dispose = source obv
+                let! dispose = AsyncObserver obv |> source.SubscribeAsync
                 let cancel () =
                     async {
-                        do! dispose ()
+                        do! dispose.DisposeAsync ()
                         innerAgent.Post Dispose
                     }
-                return cancel
+                return AsyncDisposable.Create cancel
             }
-        subscribe
+        { new IAsyncObservable<'a> with member __.SubscribeAsync o = subscribeAsync o }
 
-    let catch (handler: exn -> AsyncObservable<'a>) (source: AsyncObservable<'a>) : AsyncObservable<'a> =
-        let subscribe (aobv: AsyncObserver<'a>) =
+    /// Asynchronosly transforms the items emitted by an source sequence
+    /// into observable streams, and mirror those items emitted by the
+    /// most-recently transformed observable sequence.
+    let flatMapLatestAsync (mapper: 'a -> Async<IAsyncObservable<'b>>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> mapAsync mapper
+        |> switchLatest
+
+    /// Transforms the items emitted by an source sequence into
+    /// observable streams, and mirror those items emitted by the
+    /// most-recently transformed observable sequence.
+    let flatMapLatest (mapper: 'a -> IAsyncObservable<'b>) (source: IAsyncObservable<'a>) : IAsyncObservable<'b> =
+        source
+        |> map mapper
+        |> switchLatest
+
+
+    /// Returns an observable sequence containing the first sequence's
+    /// elements, followed by the elements of the handler sequence in
+    /// case an exception occurred.
+    let catch (handler: exn -> IAsyncObservable<'a>) (source: IAsyncObservable<'a>) : IAsyncObservable<'a> =
+        let subscribeAsync (aobv: IAsyncObserver<'a>) =
             async {
-                let mutable disposable = disposableEmpty
+                let mutable disposable = AsyncDisposable.Empty
 
-                let rec action (source: AsyncObservable<_>) = async {
-                    let _obv n = async {
-                        match n with
-                        | OnError ex ->
-                            let nextSource = handler ex
+                let rec action (source: IAsyncObservable<_>) = async {
+                    let _obv = {
+                        new IAsyncObserver<'a> with
+                        member this.OnNextAsync x = async {
+                            do! aobv.OnNextAsync x
+                        }
+                        member this.OnErrorAsync err = async {
+                            let nextSource = handler err
                             do! action nextSource
-                        | _ -> do! aobv n
+                        }
+                        member this.OnCompletedAsync () = async {
+                            do! aobv.OnCompletedAsync ()
+                        }
                     }
-
-                    do! disposable ()
-                    let! subscription = source _obv
+                    do! disposable.DisposeAsync ()
+                    let! subscription = source.SubscribeAsync _obv
                     disposable <- subscription
                 }
                 do! action source
 
                 let cancel () =
                     async {
-                        do! disposable ()
+                        do! disposable.DisposeAsync ()
                     }
-                return cancel
+                return AsyncDisposable.Create cancel
             }
-        subscribe
+        { new IAsyncObservable<'a> with member __.SubscribeAsync o = subscribeAsync o }

--- a/Sources/Types.fs
+++ b/Sources/Types.fs
@@ -5,39 +5,30 @@ type Notification<'a> =
     | OnError of exn
     | OnCompleted
 
+[<AutoOpen>]
 module Types =
-    type AsyncDisposable = unit -> Async<unit>
-    type AsyncObserver<'a> = Notification<'a> -> Async<unit>
-    type AsyncObservable<'a> = AsyncObserver<'a> -> Async<AsyncDisposable>
+    type AsyncDisposableFn = unit -> Async<unit>
+    type AsyncObserverFn<'a> = Notification<'a> -> Async<unit>
+    type AsyncObservableFn<'a> = AsyncObserverFn<'a> -> Async<AsyncDisposableFn>
 
     type Accumulator<'s, 't> = 's -> 't -> 's
+
+    type IAsyncDisposable =
+        abstract member DisposeAsync: unit -> Async<unit>
+
+    type IAsyncObserver<'a> =
+        abstract member OnNextAsync: 'a -> Async<unit>
+        abstract member OnErrorAsync: exn -> Async<unit>
+        abstract member OnCompletedAsync: unit -> Async<unit>
+
+    type IAsyncObservable<'a> =
+        abstract member SubscribeAsync: IAsyncObserver<'a> -> Async<IAsyncDisposable>
 
     type RefCountCmd =
         | Increase
         | Decrease
 
     type InnerSubscriptionCmd<'a> =
-        | InnerObservable of AsyncObservable<'a>
+        | InnerObservable of IAsyncObservable<'a>
         | Dispose
-
-
-    type MailboxProcessor<'Msg> with
-        static member StartImmediate(body, ?cancellationToken) =
-            let mb = new MailboxProcessor<'Msg>(body,?cancellationToken=cancellationToken)
-
-            // Protect the execution and send errors to the event.
-            // Note that exception stack traces are lost in this design - in an extended design
-            // the event could propagate an ExceptionDispatchInfo instead of an Exception.
-            let p = async {
-                try
-                    do! body mb
-                with exn ->
-                    printfn "Got exception: %A" exn
-                }
-
-            let token = defaultArg cancellationToken Async.DefaultCancellationToken
-
-            Async.StartImmediate(computation=p, cancellationToken=token)
-            mb
-
 

--- a/Tests/AsyncSeqTest.fs
+++ b/Tests/AsyncSeqTest.fs
@@ -4,6 +4,7 @@ open System.Collections.Generic
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit

--- a/Tests/BindTest.fs
+++ b/Tests/BindTest.fs
@@ -3,7 +3,7 @@ module Tests.Bind
 open System.Threading.Tasks
 
 open Reaction
-open Reaction.Query
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -19,7 +19,7 @@ let ``Test bind empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     try
         do! obv.AwaitIgnore ()
     with
@@ -40,7 +40,7 @@ let ``Test bind some``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -133,7 +133,7 @@ let ``Test bind expression some``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = ys.SubscribeAsync obv.PostAsync
+    let! sub = ys.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -154,7 +154,7 @@ let ``Test bind expression some for``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = ys.SubscribeAsync obv.PostAsync
+    let! sub = ys.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -175,7 +175,7 @@ let ``Test bind expression some return bang``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = ys.SubscribeAsync obv.PostAsync
+    let! sub = ys.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert

--- a/Tests/CatchTest.fs
+++ b/Tests/CatchTest.fs
@@ -3,6 +3,7 @@ module Tests.Catch
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -13,13 +14,13 @@ let toTask computation : Task = Async.StartAsTask computation :> _
 [<Test>]
 let ``Test catch no error``() = toTask <| async {
     // Arrange
-    let xs = fromNotification [ OnNext 1; OnNext 2; OnNext 3; OnCompleted]
-    let ys = fromNotification [ OnNext 4; OnNext 5; OnNext 6; OnCompleted]
+    let xs = fromNotification [ OnNext 1; OnNext 2; OnNext 3; OnCompleted ]
+    let ys = fromNotification [ OnNext 4; OnNext 5; OnNext 6; OnCompleted ]
     let zs = xs |> catch (fun _ -> ys)
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -35,13 +36,13 @@ exception MyError of string
 let ``Test catch error``() = toTask <| async {
     // Arrange
     let error = MyError "error"
-    let xs = fromNotification [ OnNext 1; OnNext 2; OnNext 3; OnError error]
-    let ys = fromNotification [ OnNext 4; OnNext 5; OnNext 6; OnCompleted]
+    let xs = fromNotification [ OnNext 1; OnNext 2; OnNext 3; OnError error ]
+    let ys = fromNotification [ OnNext 4; OnNext 5; OnNext 6; OnCompleted ]
     let zs = xs |> catch (fun _ -> ys)
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -55,7 +56,7 @@ let ``Test catch error``() = toTask <| async {
 let ``Test catch error exception is propagated``() = toTask <| async {
     // Arrange
     let error = MyError "ing"
-    let xs = fromNotification [ OnNext "test"; OnError error]
+    let xs = fromNotification [ OnNext "test"; OnError error ]
     let zs = xs |> catch (fun err ->
         let msg =
             match err with
@@ -63,10 +64,10 @@ let ``Test catch error exception is propagated``() = toTask <| async {
             | _ -> "error"
 
         single msg)
-    let obv = TestObserver<string>()
+    let obv = TestObserver<string> ()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -80,9 +81,9 @@ let ``Test catch error exception is propagated``() = toTask <| async {
 let ``Test catch error twice``() = toTask <| async {
     // Arrange
     let error = MyError "error"
-    let xs = fromNotification [ OnNext 1; OnError error]
-    let ys1 = fromNotification [ OnNext 2; OnError error]
-    let ys2 = fromNotification [ OnNext 3; OnCompleted]
+    let xs = fromNotification [ OnNext 1; OnError error ]
+    let ys1 = fromNotification [ OnNext 2; OnError error ]
+    let ys2 = fromNotification [ OnNext 3; OnCompleted ]
     let iter = [ys1; ys2] |> Seq.ofList |> fun x -> x.GetEnumerator ()
     let zs = xs |> catch (fun _ ->
         iter.MoveNext () |> ignore
@@ -91,7 +92,7 @@ let ``Test catch error twice``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert

--- a/Tests/ConcatTest.fs
+++ b/Tests/ConcatTest.fs
@@ -3,6 +3,7 @@ module Tests.Concat
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -19,7 +20,7 @@ let ``Test concat emtpy empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     try
         do! obv.AwaitIgnore ()
     with
@@ -41,7 +42,7 @@ let ``Test concat non emtpy empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -61,7 +62,7 @@ let ``Test concat empty non empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -81,7 +82,7 @@ let ``Test concat two``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -92,6 +93,7 @@ let ``Test concat two``() = toTask <| async {
     Assert.That(actual, Is.EquivalentTo(expected))
 }
 
+(*
 [<Test>]
 let ``Test concat +``() = toTask <| async {
     // Arrange
@@ -101,7 +103,7 @@ let ``Test concat +``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -111,6 +113,7 @@ let ``Test concat +``() = toTask <| async {
     let expected = [ OnNext 1; OnNext 2; OnNext 3; OnNext 4; OnNext 5; OnNext 6; OnCompleted ]
     Assert.That(actual, Is.EquivalentTo(expected))
 }
+*)
 
 [<Test>]
 let ``Test concat three``() = toTask <| async {
@@ -122,7 +125,7 @@ let ``Test concat three``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -145,7 +148,7 @@ let ``Test concat fail with non emtpy ``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     try
         do! obv.AwaitIgnore ()
     with

--- a/Tests/CreateTest.fs
+++ b/Tests/CreateTest.fs
@@ -3,6 +3,7 @@ module Tests.Just
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -13,11 +14,11 @@ let toTask computation : Task = Async.StartAsTask computation :> _
 [<Test>]
 let ``Test single happy``() = toTask <| async {
     // Arrange
-    let xs = single 42
+    let xs = AsyncObservable.single 42
     let obv = TestObserver<int>()
 
     // Act
-    let! dispose = xs.SubscribeAsync obv.PostAsync
+    let! dispose = xs.SubscribeAsync obv
 
     // Assert
     let! latest = obv.Await ()
@@ -31,11 +32,11 @@ let ``Test single happy``() = toTask <| async {
 [<Test>]
 let ``Test just dispose after subscribe``() = toTask <| async {
     // Arrange
-    let xs = single 42
+    let xs = AsyncObservable.single 42
     let obv = TestObserver<int>()
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     Async.StartImmediate (subscription.DisposeAsync ())
 
     // Assert
@@ -51,7 +52,7 @@ let ``Test ofSeq empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! dispose = xs.SubscribeAsync obv.PostAsync
+    let! dispose = xs.SubscribeAsync obv
 
     do! obv.AwaitIgnore ()
 
@@ -69,7 +70,7 @@ let ``Test ofSeq non empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! dispose = xs.SubscribeAsync obv.PostAsync
+    let! dispose = xs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert
@@ -86,7 +87,7 @@ let ``Test ofSeq dispose after subscribe``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     do! subscription.DisposeAsync ()
 
     // Assert

--- a/Tests/FilterTest.fs
+++ b/Tests/FilterTest.fs
@@ -1,9 +1,9 @@
 module Tests.Filter
 
-open System
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -23,7 +23,7 @@ let ``Test filter``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
     let! result = obv.Await ()
 
     // Assert
@@ -50,7 +50,7 @@ let ``Test filter predicate throws exception``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
 
     try
         do! obv.AwaitIgnore ()

--- a/Tests/GroupByTest.fs
+++ b/Tests/GroupByTest.fs
@@ -2,6 +2,7 @@ module Tests.GroupBy
 
 open System.Threading.Tasks
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -20,7 +21,7 @@ let ``Test groupby empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
 
     try
         do! obv.AwaitIgnore ()
@@ -44,7 +45,7 @@ let ``Test groupby error``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
 
     try
         do! obv.AwaitIgnore ()
@@ -67,7 +68,7 @@ let ``Test groupby 2 groups``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
 
     try
         do! obv.AwaitIgnore ()
@@ -90,7 +91,7 @@ let ``Test groupby cancel``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
     do! sub.DisposeAsync ()
 
     // Assert

--- a/Tests/MapTest.fs
+++ b/Tests/MapTest.fs
@@ -3,6 +3,7 @@ module Tests.Map
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -22,7 +23,7 @@ let ``Test map async``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
     let! latest= obv.Await ()
 
     // Assert
@@ -43,7 +44,7 @@ let ``Test map sync``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = xs.SubscribeAsync obv.PostAsync
+    let! sub = xs.SubscribeAsync obv
     let! latest= obv.Await ()
 
     // Assert
@@ -69,7 +70,7 @@ let ``Test map mapper throws exception``() = toTask <| async {
     let obv = TestObserver<unit>()
 
     // Act
-    let! cnl = xs.SubscribeAsync obv.PostAsync
+    let! cnl = xs.SubscribeAsync obv
 
     try
         do! obv.AwaitIgnore ()

--- a/Tests/MergeTest.fs
+++ b/Tests/MergeTest.fs
@@ -3,6 +3,7 @@ module Tests.Merge
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -16,12 +17,12 @@ let toTask computation : Task = Async.StartAsTask computation :> _
 let ``Test merge non empty emtpy``() = toTask <| async {
     // Arrange
     let xs = ofSeq <| seq { 1..5 }
-    let ys : AsyncObservable<int> = empty ()
+    let ys = empty<int> ()
     let zs = ofSeq <| [ xs; ys ] |> mergeInner
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! latest= obv.Await ()
 
     // Assert
@@ -35,13 +36,13 @@ let ``Test merge non empty emtpy``() = toTask <| async {
 [<Test>]
 let ``Test merge empty non emtpy``() = toTask <| async {
     // Arrange
-    let xs : AsyncObservable<int> = empty ()
+    let xs = empty<int> ()
     let ys = ofSeq <| seq { 1..5 }
     let zs = ofSeq <| [ xs; ys ] |> mergeInner
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     let! latest= obv.Await ()
 
     // Assert
@@ -62,7 +63,7 @@ let ``Test merge error error``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
 
     try
         do! obv.Await () |> Async.Ignore
@@ -85,7 +86,7 @@ let ``Test merge two``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! obv.AwaitIgnore ()
 
     // Assert

--- a/Tests/ObserverTest.fs
+++ b/Tests/ObserverTest.fs
@@ -16,7 +16,7 @@ let ``Test safe observer empty sequence``() = toTask <| async {
     // Arrange
     let xs = fromNotification Seq.empty
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -36,7 +36,7 @@ let ``Test safe observer error sequence``() = toTask <| async {
     let error = MyError "error"
     let xs = fromNotification [ OnError error ]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -55,9 +55,9 @@ let ``Test safe observer error sequence``() = toTask <| async {
 [<Test>]
 let ``Test safe observer happy``() = toTask <| async {
     // Arrange
-    let xs = ofSeq [ 1..3]
+    let xs = AsyncObservable.ofSeq [ 1..3]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -75,7 +75,7 @@ let ``Test safe observer stops after completed``() = toTask <| async {
     // Arrange
     let xs = fromNotification [ OnNext 1; OnCompleted; OnNext 2]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -93,7 +93,7 @@ let ``Test safe observer stops after completed completed``() = toTask <| async {
     // Arrange
     let xs = fromNotification [ OnNext 1; OnCompleted; OnCompleted]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -112,7 +112,7 @@ let ``Test safe observer stops after error``() = toTask <| async {
     let error = MyError "error"
     let xs = fromNotification [ OnNext 1; OnError error; OnNext 2]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv
@@ -134,7 +134,7 @@ let ``Test safe observer stops after error error``() = toTask <| async {
     let error = MyError "error"
     let xs = fromNotification [ OnNext 1; OnError error; OnError error]
     let obv = TestObserver<int>()
-    let safeObv = safeObserver obv.PostAsync
+    let safeObv = safeObserver obv
 
     // Act
     let! dispose = xs.SubscribeAsync safeObv

--- a/Tests/QueryTest.fs
+++ b/Tests/QueryTest.fs
@@ -3,6 +3,7 @@ module Tests.Query
 open System.Threading.Tasks
 
 open Reaction
+open Reaction.AsyncObservable
 
 open NUnit.Framework
 open FsUnit
@@ -20,7 +21,7 @@ let ``test empty query`` () = toTask <| async {
     let obv = TestObserver<unit>()
 
     // Act
-    let! dispose = xs.SubscribeAsync obv.PostAsync
+    let! dispose = xs.SubscribeAsync obv
 
     // Assert
     try
@@ -47,7 +48,7 @@ let ``test query let!`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -66,7 +67,7 @@ let ``test query yield!`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -85,7 +86,7 @@ let ``test query yield`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -105,7 +106,7 @@ let ``test query combine`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -126,7 +127,7 @@ let ``test query for in observable`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -146,7 +147,7 @@ let ``test query for in seq`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert
@@ -166,7 +167,7 @@ let ``test query async`` () = toTask <| async {
     }
 
     // Act
-    let! subscription = xs.SubscribeAsync obv.PostAsync
+    let! subscription = xs.SubscribeAsync obv
     let! latest = obv.Await ()
 
     // Assert

--- a/Tests/SwitchTest.fs
+++ b/Tests/SwitchTest.fs
@@ -2,12 +2,14 @@ module Tests.Switch
 
 open System.Threading.Tasks
 open Reaction
+open Reaction.AsyncObservable
+open Reaction.Streams
 
 open NUnit.Framework
 open FsUnit
 open Tests.Utils
 
-exception  MyError of string
+exception MyError of string
 
 let toTask computation : Task = Async.StartAsTask computation :> _
 
@@ -16,13 +18,13 @@ let ``Test switch2``() = toTask <| async {
     // Arrange
     let obvA, a = stream<int> ()
     let obvB, b = stream<int> ()
-    let obvX, xs = stream<AsyncObservable<int>> ()
+    let obvX, xs = stream<IAsyncObservable<int>> ()
     let ys = xs |> flatMapLatest (fun x -> x)
 
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = ys.SubscribeAsync obv.PostAsync
+    let! sub = ys.SubscribeAsync obv
 
     do! obvX.OnNextAsync a
     do! Async.Sleep 100

--- a/Tests/TakeUntilTest.fs
+++ b/Tests/TakeUntilTest.fs
@@ -2,6 +2,8 @@ module Tests.TakeUntil
 
 open System.Threading.Tasks
 open Reaction
+open Reaction.AsyncObservable
+open Reaction.Streams
 
 open NUnit.Framework
 open FsUnit
@@ -21,7 +23,7 @@ let ``Test take until empty``() = toTask <| async {
     let obv = TestObserver<int>()
 
     // Act
-    let! sub = zs.SubscribeAsync obv.PostAsync
+    let! sub = zs.SubscribeAsync obv
     do! Async.Sleep 100
     do! obvX.OnNextAsync 1
     do! obvX.OnNextAsync 2

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="BindTest.fs" />
     <Compile Include="TakeUntilTest.fs" />
     <Compile Include="AsyncSeqTest.fs" />
+    <Compile Include="SwitchTest.fs" />
     <Compile Include="QueryTest.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/Tests/Utils.fs
+++ b/Tests/Utils.fs
@@ -15,6 +15,17 @@ type TestObserver<'a>() =
 
     member this.Notifications = notifications
 
+    interface IAsyncObserver<'a> with
+        member this.OnNextAsync x = async {
+            do! this.PostAsync (OnNext x)
+        }
+        member this.OnErrorAsync err = async {
+            do! this.PostAsync (OnError err)
+        }
+        member this.OnCompletedAsync () = async {
+            do! this.PostAsync OnCompleted
+        }
+
     member this.PostAsync (n : Notification<'a>) =
         async {
             printfn "TestObserver %A" n
@@ -45,15 +56,20 @@ type TestObserver<'a>() =
         }
 
 let fromNotification (notifications : seq<Notification<'a>>) =
-    let obs = Creation.ofAsyncWorker (fun obv token -> async {
+    Create.ofAsyncWorker (fun obv token -> async {
         for notification in notifications do
             if token.IsCancellationRequested then
                 raise (OperationCanceledException("Operation cancelled"))
 
-            try
-                do! notification |> obv
-            with ex ->
-                do! OnError ex |> obv
+            match notification with
+            | OnNext x ->
+                try
+                    do! obv.OnNextAsync x
+                with err ->
+                    do! obv.OnErrorAsync err
+            | OnError err ->
+                do! obv.OnErrorAsync err
+            | OnCompleted ->
+                do! obv.OnCompletedAsync ()
     })
-    AsyncObservable obs
 


### PR DESCRIPTION
Decided to rewrite to IAsyncObservable to avoid the wrapped world and two different implementations. A lot of code was just type conversion. This brings us closer to C# compatibility.